### PR TITLE
Update how to execute script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Used to regenerate keys for customers
 # Execute
 
 chmod +x ssh_generate.py
-./ssh_generate.py "<CIRCLE_API_TOKEN>" "<ORG>" "<VCS>"
+./ssh_generate.py "PERSONAL_CIRCLE_API_TOKEN" "ORG" "VCS"


### PR DESCRIPTION
The readme was filtering out the values in `<ORG>` and `<VCS>` before so this update will ensure this shows the proper way to run the script.